### PR TITLE
Another fix for #308

### DIFF
--- a/ogsr_engine/xrGame/WeaponMagazinedWGrenade.cpp
+++ b/ogsr_engine/xrGame/WeaponMagazinedWGrenade.cpp
@@ -228,6 +228,8 @@ void CWeaponMagazinedWGrenade::OnShot		()
 		
 		AddShotEffector		();
 		
+		PlayAnimShoot();
+
 		//партиклы огня вылета гранаты из подствольника
 		StartFlameParticles2();
 	} 


### PR DESCRIPTION
`CWeaponMagazinedWGrenade::PlayAnimShoot()` was not called at all when firing a grenade launcher.